### PR TITLE
first pass at plugging in materialite

### DIFF
--- a/frontend/app.tsx
+++ b/frontend/app.tsx
@@ -223,12 +223,7 @@ function makeIssueComparator(ordering: Order) {
   return (l: Issue, r: Issue) => {
     const leftKey = getOrderValue(ordering, l);
     const rightKey = getOrderValue(ordering, r);
-    if (leftKey < rightKey) {
-      return -1;
-    } else if (leftKey > rightKey) {
-      return 1;
-    }
-    return 0;
+    return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
   };
 }
 
@@ -267,11 +262,11 @@ function reducer(
         views: {
           issueCount: state.issueSource.stream
             .filter(filters.viewFilter)
-            .linearCount()
-            .materialize((s) => new PrimitiveView(s, 0)),
+            .size()
+            .materializePrimitive(0),
           filteredIssues: state.issueSource.stream
             .filter(filters.issuesFilter)
-            .materialize((s) => new PersistentTreeView(s, issueComparator)),
+            .materialize(issueComparator),
         },
         filters: action.filters,
       };
@@ -287,7 +282,7 @@ function reducer(
           ...state.views,
           filteredIssues: state.issueSource.stream
             .filter(filters.issuesFilter)
-            .materialize((s) => new PersistentTreeView(s, issueComparator)),
+            .materialize(issueComparator),
         },
         issueOrder: action.issueOrder,
       };
@@ -360,12 +355,9 @@ const App = ({ rep, undoManager }: AppProps) => {
         ...arg,
         issueSource: source,
         views: {
-          issueCount: source.stream
-            .linearCount()
-            .materialize((s) => new PrimitiveView(s, 0)),
+          issueCount: source.stream.size().materializePrimitive(0),
           filteredIssues: source.stream.materialize(
-            (s) =>
-              new PersistentTreeView(s, makeIssueComparator(arg.issueOrder))
+            makeIssueComparator(arg.issueOrder)
           ),
         },
       };

--- a/frontend/issue-detail.tsx
+++ b/frontend/issue-detail.tsx
@@ -27,11 +27,12 @@ import { nanoid } from "nanoid";
 import { timeAgo } from "../util/date";
 import { useKeyPressed } from "./hooks/useKeyPressed";
 import { sortBy } from "lodash";
+import type { PersistentTreeView } from "@vlcn.io/materialite";
 
 interface Props {
   onUpdateIssues: (issueUpdates: IssueUpdate[]) => void;
   onAddComment: (comment: Comment) => void;
-  issues: Issue[];
+  issues: PersistentTreeView<Issue>["data"];
   isLoading: boolean;
   rep: Replicache<M>;
 }
@@ -168,12 +169,12 @@ export default function IssueDetail({
         if (currentIssueIdx === 0) {
           return;
         }
-        newIss = issues[currentIssueIdx - 1].id;
+        newIss = issues.at(currentIssueIdx - 1).id;
       } else {
         if (currentIssueIdx === issues.length - 1) {
           return;
         }
-        newIss = issues[currentIssueIdx + 1].id;
+        newIss = issues.at(currentIssueIdx + 1).id;
       }
 
       await setDetailIssueID(newIss, {

--- a/frontend/issue-list.tsx
+++ b/frontend/issue-list.tsx
@@ -10,22 +10,23 @@ import IssueRow from "./issue-row";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList } from "react-window";
 import type { Issue, IssueUpdate, Priority, Status } from "./issue";
+import type { PersistentTreeSink } from "@vlcn.io/materialite";
 
 interface Props {
   onUpdateIssues: (issueUpdates: IssueUpdate[]) => void;
   onOpenDetail: (issue: Issue) => void;
-  issues: Issue[];
+  issues: PersistentTreeSink<Issue>["data"];
   view: string | null;
 }
 
 type ListData = {
-  issues: Issue[];
+  issues: PersistentTreeSink<Issue>["data"];
   handleChangePriority: (issue: Issue, priority: Priority) => void;
   handleChangeStatus: (issue: Issue, status: Status) => void;
   onOpenDetail: (issue: Issue) => void;
 };
 
-const itemKey = (index: number, data: ListData) => data.issues[index].id;
+const itemKey = (index: number, data: ListData) => data.issues.at(index).id;
 
 const RawRow = ({
   data,
@@ -38,7 +39,7 @@ const RawRow = ({
 }) => (
   <div style={style}>
     <IssueRow
-      issue={data.issues[index]}
+      issue={data.issues.at(index)}
       onChangePriority={data.handleChangePriority}
       onChangeStatus={data.handleChangeStatus}
       onOpenDetail={data.onOpenDetail}
@@ -90,7 +91,7 @@ const IssueList = ({ onUpdateIssues, onOpenDetail, issues, view }: Props) => {
           <FixedSizeList
             ref={fixedSizeListRef}
             height={height}
-            itemCount={issues.length}
+            itemCount={issues.size}
             itemSize={43}
             itemData={itemData}
             itemKey={itemKey}

--- a/frontend/issue-list.tsx
+++ b/frontend/issue-list.tsx
@@ -10,17 +10,17 @@ import IssueRow from "./issue-row";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList } from "react-window";
 import type { Issue, IssueUpdate, Priority, Status } from "./issue";
-import type { PersistentTreeSink } from "@vlcn.io/materialite";
+import type { PersistentTreeView } from "@vlcn.io/materialite";
 
 interface Props {
   onUpdateIssues: (issueUpdates: IssueUpdate[]) => void;
   onOpenDetail: (issue: Issue) => void;
-  issues: PersistentTreeSink<Issue>["data"];
+  issues: PersistentTreeView<Issue>["data"];
   view: string | null;
 }
 
 type ListData = {
-  issues: PersistentTreeSink<Issue>["data"];
+  issues: PersistentTreeView<Issue>["data"];
   handleChangePriority: (issue: Issue, priority: Priority) => void;
   handleChangeStatus: (issue: Issue, status: Status) => void;
   onOpenDetail: (issue: Issue) => void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@rocicorp/undo": "^0.2.0",
         "@tailwindcss/forms": "^0.5.0",
         "@tailwindcss/line-clamp": "^0.3.1",
+        "@vlcn.io/materialite": "file:../vulcan/materialite/public/packages/materialite",
         "classnames": "^2.3.1",
         "fractional-indexing": "^3.0.1",
         "gzip-loader": "^0.0.1",
@@ -59,6 +60,19 @@
         "tailwindcss": "^3.0.23",
         "ts-node": "^10.7.0",
         "typescript": "^4.9.3"
+      }
+    },
+    "../vulcan/materialite/public/packages/materialite": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@vlcn.io/ds-and-algos": "workspace:*",
+        "immutable": "5.0.0-beta.4",
+        "map2": "^1.1.2"
+      },
+      "devDependencies": {
+        "typescript": "^5.2.2",
+        "vitest": "^0.34.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3862,6 +3876,10 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "node_modules/@vlcn.io/materialite": {
+      "resolved": "../vulcan/materialite/public/packages/materialite",
+      "link": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -12543,6 +12561,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "@vlcn.io/materialite": {
+      "version": "file:../vulcan/materialite/public/packages/materialite",
+      "requires": {
+        "@vlcn.io/ds-and-algos": "workspace:*",
+        "immutable": "5.0.0-beta.4",
+        "map2": "^1.1.2",
+        "typescript": "^5.2.2",
+        "vitest": "^0.34.6"
+      }
     },
     "abort-controller": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-window": "^1.8.6",
     "replicache": ">=13.0.0",
     "replicache-react": "3.0.0",
-    "zod": "^3.13.4"
+    "zod": "^3.13.4",
+    "@vlcn.io/materialite": "file:../vulcan/materialite/public/packages/materialite"
   },
   "devDependencies": {
     "@svgr/webpack": "^6.2.1",


### PR DESCRIPTION
# Problems & TODO

## Problems
- [ ] Changing filters does not work given we need to re-send old events to the new pipeline
- [x] API is a bit awkward with `view`, `view.data` and `source`
   - [x] API is a bit verbose with having to manage the source + pipeline + view
- [x] PersistentTree needs a `findIndex` function for the issue detail view to work
- [ ] Publish [materialite](https://github.com/vlcn-io/materialite) to npm rather than linking off the filesystem
    - available here: http://npmjs.com/@vlcn.io/materialite 
- [x] Hot reload extends the issue set each time
   - We can fix this by going back to the original idea of a `MapSource` which knows of entries already in the map

## Todo (follow up PRs)
- [ ] Kanban clarification...
- [ ] Add new filters
- [ ] Generate 5x the data

# Perf Difference

This was just measured by clicking through the app. Can get more serious later.

## Before (2ms-5ms):
<img width="859" alt="orig" src="https://github.com/tantaman/repliear/assets/1009003/ddaff235-1720-4039-aa01-189c41c792c1">

## After (0ms-1ms):
<img width="852" alt="new" src="https://github.com/tantaman/repliear/assets/1009003/57f1f795-363b-4cb9-92d3-f3df2dc12f84">

