### PR TITLE
[materialite] repliear + materialite [1/3]

### DIFF
--- a/backend/sample-issues.ts
+++ b/backend/sample-issues.ts
@@ -50,7 +50,7 @@ export async function getReactSampleData(): Promise<SampleData> {
 
   // Can use this to generate artifically larger datasets for stress testing.
   const multiplied: SampleData = [];
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 10; i++) {
     multiplied.push(
       ...issues.map((issue) => ({
         ...issue,

--- a/backend/sample-issues.ts
+++ b/backend/sample-issues.ts
@@ -50,7 +50,7 @@ export async function getReactSampleData(): Promise<SampleData> {
 
   // Can use this to generate artifically larger datasets for stress testing.
   const multiplied: SampleData = [];
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 5; i++) {
     multiplied.push(
       ...issues.map((issue) => ({
         ...issue,

--- a/frontend/issue-board.tsx
+++ b/frontend/issue-board.tsx
@@ -77,7 +77,7 @@ interface Props {
 }
 
 function IssueBoard({ issues, onUpdateIssues, onOpenDetail }: Props) {
-  const issuesByType = getIssueByType(issues);
+  const issuesByType = getIssueByType(issues); // TODO (mlaw): incrementalize
 
   const handleDragEnd = useCallback(
     ({ source, destination }: DropResult) => {

--- a/frontend/issue-detail.tsx
+++ b/frontend/issue-detail.tsx
@@ -27,11 +27,12 @@ import { nanoid } from "nanoid";
 import { timeAgo } from "../util/date";
 import { useKeyPressed } from "./hooks/useKeyPressed";
 import { sortBy } from "lodash";
+import type { PersistentTreeView } from "@vlcn.io/materialite";
 
 interface Props {
   onUpdateIssues: (issueUpdates: IssueUpdate[]) => void;
   onAddComment: (comment: Comment) => void;
-  issues: Issue[];
+  issues: PersistentTreeView<Issue>["data"];
   isLoading: boolean;
   rep: Replicache<M>;
 }
@@ -168,12 +169,12 @@ export default function IssueDetail({
         if (currentIssueIdx === 0) {
           return;
         }
-        newIss = issues[currentIssueIdx - 1].id;
+        newIss = issues.at(currentIssueIdx - 1).id;
       } else {
         if (currentIssueIdx === issues.length - 1) {
           return;
         }
-        newIss = issues[currentIssueIdx + 1].id;
+        newIss = issues.at(currentIssueIdx + 1).id;
       }
 
       await setDetailIssueID(newIss, {

--- a/frontend/issue-list.tsx
+++ b/frontend/issue-list.tsx
@@ -10,22 +10,23 @@ import IssueRow from "./issue-row";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList } from "react-window";
 import type { Issue, IssueUpdate, Priority, Status } from "./issue";
+import type { PersistentTreeView } from "@vlcn.io/materialite";
 
 interface Props {
   onUpdateIssues: (issueUpdates: IssueUpdate[]) => void;
   onOpenDetail: (issue: Issue) => void;
-  issues: Issue[];
+  issues: PersistentTreeView<Issue>["data"];
   view: string | null;
 }
 
 type ListData = {
-  issues: Issue[];
+  issues: PersistentTreeView<Issue>["data"];
   handleChangePriority: (issue: Issue, priority: Priority) => void;
   handleChangeStatus: (issue: Issue, status: Status) => void;
   onOpenDetail: (issue: Issue) => void;
 };
 
-const itemKey = (index: number, data: ListData) => data.issues[index].id;
+const itemKey = (index: number, data: ListData) => data.issues.at(index).id;
 
 const RawRow = ({
   data,
@@ -38,7 +39,7 @@ const RawRow = ({
 }) => (
   <div style={style}>
     <IssueRow
-      issue={data.issues[index]}
+      issue={data.issues.at(index)}
       onChangePriority={data.handleChangePriority}
       onChangeStatus={data.handleChangeStatus}
       onOpenDetail={data.onOpenDetail}
@@ -90,7 +91,7 @@ const IssueList = ({ onUpdateIssues, onOpenDetail, issues, view }: Props) => {
           <FixedSizeList
             ref={fixedSizeListRef}
             height={height}
-            itemCount={issues.length}
+            itemCount={issues.size}
             itemSize={43}
             itemData={itemData}
             itemKey={itemKey}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@rocicorp/undo": "^0.2.0",
         "@tailwindcss/forms": "^0.5.0",
         "@tailwindcss/line-clamp": "^0.3.1",
+        "@vlcn.io/materialite": "^2.0.0",
         "classnames": "^2.3.1",
         "fractional-indexing": "^3.0.1",
         "gzip-loader": "^0.0.1",
@@ -3863,6 +3864,21 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "node_modules/@vlcn.io/ds-and-algos": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vlcn.io/ds-and-algos/-/ds-and-algos-2.0.0.tgz",
+      "integrity": "sha512-YtvJHJ1aDXlCm1TwspYvBNIyQZPkcAfImcUjbgg5cxYLN4dXDgb5sf1r65AcpHdWd3aKeHcfSXhTwKmnUPqIZw=="
+    },
+    "node_modules/@vlcn.io/materialite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vlcn.io/materialite/-/materialite-2.0.0.tgz",
+      "integrity": "sha512-9gAHXyGP50V9G3bRGNkAT4aG8I0b/lyruZGBWemWYrW1RD3sZqRHGLBdOKOoPI4mdN0Usn/FFceUrDFAlHT/9w==",
+      "dependencies": {
+        "@vlcn.io/ds-and-algos": "2.0.0",
+        "immutable": "5.0.0-beta.4",
+        "map2": "^1.1.2"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -6145,6 +6161,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.0-beta.4.tgz",
+      "integrity": "sha512-sl9RE3lqd2LoQSESc8VV0k8qE9y57iT7dinq3Q+8mR2dqReHDZlgUrudzmFfZhDXBLXlNJMVWv3SG1YpQIokig=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6803,6 +6824,11 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "devOptional": true
+    },
+    "node_modules/map2": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/map2/-/map2-1.1.2.tgz",
+      "integrity": "sha512-Kdt76+hzoMwA+Kiih0xtvBuuMrNbdBSZfZ4oC2hLBwp2uk3b3FopFEc/NkWu43ba1Fj93vmjxJ2DC0rfaI9W+w=="
     },
     "node_modules/mdast-util-definitions": {
       "version": "4.0.0",
@@ -12544,6 +12570,21 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@vlcn.io/ds-and-algos": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vlcn.io/ds-and-algos/-/ds-and-algos-2.0.0.tgz",
+      "integrity": "sha512-YtvJHJ1aDXlCm1TwspYvBNIyQZPkcAfImcUjbgg5cxYLN4dXDgb5sf1r65AcpHdWd3aKeHcfSXhTwKmnUPqIZw=="
+    },
+    "@vlcn.io/materialite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vlcn.io/materialite/-/materialite-2.0.0.tgz",
+      "integrity": "sha512-9gAHXyGP50V9G3bRGNkAT4aG8I0b/lyruZGBWemWYrW1RD3sZqRHGLBdOKOoPI4mdN0Usn/FFceUrDFAlHT/9w==",
+      "requires": {
+        "@vlcn.io/ds-and-algos": "2.0.0",
+        "immutable": "5.0.0-beta.4",
+        "map2": "^1.1.2"
+      }
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -14222,6 +14263,11 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
+    "immutable": {
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.0-beta.4.tgz",
+      "integrity": "sha512-sl9RE3lqd2LoQSESc8VV0k8qE9y57iT7dinq3Q+8mR2dqReHDZlgUrudzmFfZhDXBLXlNJMVWv3SG1YpQIokig=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -14688,6 +14734,11 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "devOptional": true
+    },
+    "map2": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/map2/-/map2-1.1.2.tgz",
+      "integrity": "sha512-Kdt76+hzoMwA+Kiih0xtvBuuMrNbdBSZfZ4oC2hLBwp2uk3b3FopFEc/NkWu43ba1Fj93vmjxJ2DC0rfaI9W+w=="
     },
     "mdast-util-definitions": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "replicache": ">=13.0.0",
     "replicache-react": "3.0.0",
     "zod": "^3.13.4",
-    "@vlcn.io/materialite": "file:../vulcan/materialite/public/packages/materialite"
+    "@vlcn.io/materialite": "^2.0.0"
   },
   "devDependencies": {
     "@svgr/webpack": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-window": "^1.8.6",
     "replicache": ">=13.0.0",
     "replicache-react": "3.0.0",
-    "zod": "^3.13.4"
+    "zod": "^3.13.4",
+    "@vlcn.io/materialite": "file:../vulcan/materialite/public/packages/materialite"
   },
   "devDependencies": {
     "@svgr/webpack": "^6.2.1",


### PR DESCRIPTION
Later PRs:

- incrementally maintain the kanban board. Working in: https://github.com/tantaman/repliear/pull/4
- ref count operators rather than destroying at source. For a future PR.

---
This PR:

Scaled to 10x the issues (113,070)

**The good:**
- updates take ~2-4ms on this branch vs ~20ms without these changes.
  - note: we can get this down to 1-2ms via a source which doesn't retain values. Materialite is saving values in the source (SetSource / MapSource) as well as the resulting view. Replicache already has the values so we could remove the extra copy we're maintaining in the source set.
- page refresh is 4x faster on this branch (0.5 seconds to load all issues vs 2 seconds)
- ~80 lines less code (package.lock.json accounts for 50 line additions in the diff)

**The meh:**
- Completely changing filters can be 3x slower. **Update: We can fix all of this by sorting the set _before_ materializing the set**
   - Depends on result size.
   - To go from a filtered set to showing all 100,000 results takes 300ms where as the original implementation takes 100ms. 
   - In a way this is expected -- updating an immutable tree with the entire result set is slower than copying an array of the entire result set. In a way it is unexpected since full page refresh is 4x faster on this branch.
   - The smaller the resulting filtered set, the smaller the perf difference.

Another good test would be typing and updating the issue table as the user types. Based on my other experiments, this works fine with materialite (we do very few allocations) where as it quickly crashes otherwise (too many array copies).

**Unrelated things I noticed:**
1. Two diffs are fired for each change event. The first changes the field and modified time, the second changes the modified time again without changing anything else.

![Screenshot 2023-10-25 at 9 39 50 AM](https://github.com/tantaman/repliear/assets/1009003/9bc09ae8-80d6-4c92-aef8-85286eb63c9c)

![Screenshot 2023-10-25 at 9 40 26 AM](https://github.com/tantaman/repliear/assets/1009003/b9f811bd-eb25-4225-a5be-50e6a0bd0e3e)

![Screenshot 2023-10-25 at 9 40 28 AM](https://github.com/tantaman/repliear/assets/1009003/e7cc80b6-7b0a-4c80-b046-71f1d6c0b7a0)


2. the `onSuccess` callback inside replicache that is invoked after a mutation often causes a bunch of frame drops

![Screenshot 2023-10-25 at 9 33 25 AM](https://github.com/tantaman/repliear/assets/1009003/fcb6bc50-4dbc-4e0f-b105-4d4478554f69)

3. After leaving `repliear` open a while (both on this branch and on main), it just starts frame dropping like crazy and all interactions are slow (even just moving the mouse and not clicking anything)

![Screenshot 2023-10-25 at 10 13 53 AM](https://github.com/tantaman/repliear/assets/1009003/e8bceea1-4daa-45cb-8a44-cb9b083ab668)

4. initial load time is also much faster on this branch. This is great but unexpected.

**Before (2+ seconds to refresh):**

https://github.com/tantaman/repliear/assets/1009003/df876de6-018e-471b-9119-787927e7b9a5

**After (0.5 second to refresh):**

https://github.com/tantaman/repliear/assets/1009003/c1923048-a5b0-4d32-9d8c-5710a7ddd54f



